### PR TITLE
Use SSB-Identities

### DIFF
--- a/ssb-node/package.json
+++ b/ssb-node/package.json
@@ -21,14 +21,15 @@
     "ssb-config": "^3.2.3",
     "ssb-friends": "^3.1.12",
     "ssb-gossip": "^1.0.4",
+    "ssb-identities": "^2.0.7",
     "ssb-invite": "^2.0.3",
     "ssb-keys": "^7.1.4",
     "ssb-ref": "^2.13.9",
     "ssb-replicate": "^1.0.4",
     "ssb-server": "^14.0.3",
     "ssb-tunnel": "^1.2.0",
-    "vorpal": "^1.11.4",
-    "tiny-worker": "^2.1.2"
+    "tiny-worker": "^2.1.2",
+    "vorpal": "^1.11.4"
   },
   "scripts": {
     "start": "node src/index.js"

--- a/ssb-node/src/commands/publish.js
+++ b/ssb-node/src/commands/publish.js
@@ -25,7 +25,11 @@ module.exports = function(cli, config, state) {
                     }
                 }
 
-                state.ssb_server.publish(publishMessage, function (err, msg) {
+                state.ssb_server.identities.publishAs({
+                    id: state.ssb_server.id,
+                    content: publishMessage,
+                    private: false,
+                }, function (err, msg) {
                     if (err) {
                         logErr(err)
                     } else if (args.options.verbose) {

--- a/ssb-node/src/util/server.js
+++ b/ssb-node/src/util/server.js
@@ -17,6 +17,7 @@ var createSbot = require('ssb-server')
     .use(require('ssb-blobs'))
     .use(require('ssb-invite'))
     .use(require('ssb-tunnel'))
+    .use(require('ssb-identities'))
     .use(require('../plugins/chat'));
 
 let server;


### PR DESCRIPTION
We use ssb-identities to post in the Everlife node. I think we should do the same here. We can also add publishing private messages etc to match the functionality available in the node.